### PR TITLE
Specify bundle for localized Text in onboarding views

### DIFF
--- a/Sources/OnboardingKit/Screens/Welcome/Subviews/BottomSection.swift
+++ b/Sources/OnboardingKit/Screens/Welcome/Subviews/BottomSection.swift
@@ -69,7 +69,7 @@ extension BottomSection: View {
         Group {
             Text(verbatim: .dataPrivacy(for: appDisplayName))
                 .foregroundStyle(.secondary) +
-            Text(.dataPrivacyButtonTitle)
+            Text(.dataPrivacyButtonTitle, bundle: .module)
                 .foregroundStyle(accentColor)
                 .bold()
         }
@@ -91,7 +91,7 @@ extension BottomSection: View {
     }
 
     private func continueText() -> some View {
-        Text(.continueButtonTitle)
+        Text(.continueButtonTitle, bundle: .module)
             .padding(.vertical, 6)
             .frame(maxWidth: .infinity)
     }

--- a/Sources/OnboardingKit/Screens/Welcome/Subviews/TitleSection.swift
+++ b/Sources/OnboardingKit/Screens/Welcome/Subviews/TitleSection.swift
@@ -61,7 +61,7 @@ extension TitleSection: View {
     }
 
     private var welcomeToText: some View {
-        Text(.welcomeTo)
+        Text(.welcomeTo, bundle: .module)
             .foregroundColor(.primary)
             .fontWeight(.semibold)
     }


### PR DESCRIPTION
Updated Text initializers in BottomSection and TitleSection to explicitly specify the .module bundle for localized strings. This ensures correct string resolution when the module is used as a Swift Package.

Closes #15 